### PR TITLE
Filter redirected posts from Atom feed

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -16,6 +16,9 @@ layout: null
  </author>
 
  {% for post in site.posts %}
+  {% if post.layout == 'redirect' %}
+   {% continue %}
+  {% endif %}
  <entry>
    <title>{{ post.title }}</title>
    <link href="{{ site.url }}{{ post.url }}"/>


### PR DESCRIPTION
Hello Nicholas, I didn't know how to contact you. I noticed your Atom feed contains entries for redirected posts.
