### PR TITLE
Copy editing.

### DIFF
--- a/_posts/2016-10-21-anim_compression_toc.md
+++ b/_posts/2016-10-21-anim_compression_toc.md
@@ -3,36 +3,31 @@ layout: post
 title: "Animation Compression: Table of Contents"
 toc: "Animation Compression"
 ---
-I will soon present at the [GDC 2017](http://www.gdconf.com/) a new approach to character animation compression. While the topic is warm and fresh in my memory, I thought it would do me some good to take a break from [memory allocators]({% post_url 2016-10-18-memory_allocators_toc %}) and talk about the various approaches to this. I also happen to have some free time ahead of me before I find and start my next contract.
+Character animation compression is an exotic topic that seems to need to be re-approached only about once per decade. Over the course of 2016 I’ve been developing this decades new approach and I was lucky enough to be invited to talk about the various implementations I’ve found at the [2017 Game Developers Conference(GDC)](http://www.gdconf.com/).
 
-While I will not be able to cover the presentation content prior to the conference, I will cover as much material as I can while leading up to it and eventually it will make its way on here.
+The amount of material available regarding animation compression is surprisingly thin and often poorly detailed. My hope for this series is to serve as a reference for anyone looking to improve upon or implement efficient character animation compression techniques.
 
-This post is meant as a table of content that will link to all the relevant topics I will cover. It will be updated as time goes by and as material is published.
+Each post is self-contained and detailed enough to be approachable to a wide audience.
 
-I will do my best to keep this series of posts self contained and detailed enough to be approachable to a wide audience. The amount of material out there regarding animation compression is surprisingly very thin or often poorly detailed. My hope is for this series to serve as a reference for anyone curious about this topic and looking at improving or implementing these techniques.
+*[GDC 2017 Presentation](http://schedule.gdconf.com/session/simple-and-powerful-animation-compression)*
 
-If time permits, and if I can get approval from various relevant parties, I might go ahead and implement some of these techniques into an actual production ready library.
+# Table of Contents
 
-*[Upcoming GDC 2017 Presentation](http://schedule.gdconf.com/session/simple-and-powerful-animation-compression)*
-
-# Table of Content
-
-* [Preface]({% post_url 2016-10-25-anim_compression_preface %})
-* [Terminology]({% post_url 2016-10-26-anim_compression_terminology %})
-* [Animation Data]({% post_url 2016-10-27-anim_compression_data %})
-* [Measuring Compression Accuracy]({% post_url 2016-11-01-anim_compression_accuracy %})
-* [Constant Tracks]({% post_url 2016-11-03-anim_compression_constant_tracks %})
-* [Range Reduction]({% post_url 2016-11-09-anim_compression_range_reduction %})
-* [Uniform Segmenting]({% post_url 2016-11-10-anim_compression_uniform_segmenting %})
-* [Main Compression Families]({% post_url 2016-11-13-anim_compression_families %})
-  * [Simple Quantization]({% post_url 2016-11-15-anim_compression_quantization %})
-  * *Advanced Quantization (Coming soon post-GDC!)*
-  * [Sub-sampling]({% post_url 2016-11-17-anim_compression_sub_sampling %})
-  * [Linear Key Reduction]({% post_url 2016-12-07-anim_compression_key_reduction %})
-  * [Curve Fitting]({% post_url 2016-12-10-anim_compression_curve_fitting %})
-  * [Signal Processing]({% post_url 2016-12-19-anim_compression_signal_processing %})
-* [Error Compensation]({% post_url 2016-12-22-anim_compression_error_compensation %})
-* [Case Studies]({% post_url 2016-12-23-anim_compression_case_studies %})
-  * [Unreal 4]({% post_url 2017-01-11-anim_compression_unreal4 %})
-  * [Unity 5]({% post_url 2017-01-30-anim_compression_unity5 %})
-
+*   [Preface]({% post_url 2016-10-25-anim_compression_preface %})
+*   [Terminology]({% post_url 2016-10-26-anim_compression_terminology %})
+*   [Animation Data]({% post_url 2016-10-27-anim_compression_data %})
+*   [Measuring Compression Accuracy]({% post_url 2016-11-01-anim_compression_accuracy %})
+*   [Constant Tracks]({% post_url 2016-11-03-anim_compression_constant_tracks %})
+*   [Range Reduction]({% post_url 2016-11-09-anim_compression_range_reduction %})
+*   [Uniform Segmenting]({% post_url 2016-11-10-anim_compression_uniform_segmenting %})
+*   [Main Compression Families]({% post_url 2016-11-13-anim_compression_families %})
+    *   [Simple Quantization]({% post_url 2016-11-15-anim_compression_quantization %})
+    *   *Advanced Quantization (Coming soon post-GDC!)*
+    *   [Sub-sampling]({% post_url 2016-11-17-anim_compression_sub_sampling %})
+    *   [Linear Key Reduction]({% post_url 2016-12-07-anim_compression_key_reduction %})
+    *   [Curve Fitting]({% post_url 2016-12-10-anim_compression_curve_fitting %})
+    *   [Signal Processing]({% post_url 2016-12-19-anim_compression_signal_processing %})
+*   [Error Compensation]({% post_url 2016-12-22-anim_compression_error_compensation %})
+*   [Case Studies]({% post_url 2016-12-23-anim_compression_case_studies %})
+    *   [Unreal 4]({% post_url 2017-01-11-anim_compression_unreal4 %})
+    *   [Unity 5]({% post_url 2017-01-30-anim_compression_unity5 %})

--- a/_posts/2016-11-01-anim_compression_accuracy.md
+++ b/_posts/2016-11-01-anim_compression_accuracy.md
@@ -2,51 +2,48 @@
 layout: post
 title: "Animation Compression: Measuring Accuracy"
 ---
-How we measure our compression accuracy is critically important. Since all the compression algorithms we will cover are lossy in nature, how we measure the deviation from the source data needs to be representative of the visual difference we might observe.
+Every compression algorithm covered herein is lossy in nature, so how we measure accuracy is critically important. Measured deviation from source data needs to be representative of the visual differences observed.
 
-It is also important to allow us to compare our algorithms against each other. You might be surprised to learn that a lot of academic papers on this topic use varying error metrics making any meaningful comparison quite hard.
+It is also important to compare algorithms against each other. It is surprising to learn that many academic papers on this topic use varying error metrics making meaningful comparison quite difficult.
 
-Our error measuring function needs to satisfy a small number of important properties:
+Error measuring needs to meet a number of important criteria:
 
-* We need to take into account the hierarchical nature our data since the error will accumulate down the hierarchy when using local space transforms
-* We need to account for the error in all three tracks for every bone
-* We need to account for the fact that the visual mesh almost never overlaps with the skeleton and the further away a vertex is from its bone, the larger the error will end up being
+*   Account for the hierarchical nature the data since errors accumulate down the hierarchy when using local space transforms
+*   Account for errors in all three tracks for every bone
+*   Account for the fact that visual mesh almost never overlaps with its skeleton and the further away a vertex is from its bone the larger the error will end up being
 
 # Object Space vs Local Space
+For compression reasons, transforms and blending poses are usually stored in local space. However, due to the hierarchical nature, a small error on a parent bone could end up causing a much larger error on a child’s bone further down. For this reason, errors are best measured in object space.
 
-For compression reasons, our transforms are usually stored in local space. Local space is also often used when blending poses at runtime as such it is the most common format. However, due to the hierarchical nature, a small error on a parent bone could end up causing a much larger error on a child bone further down. For this reason, the error is best measured in object space.
-
-Surprisingly, it is quite common for compression algorithms to use local space instead to measure error. Very often, this is how the error is measured with linear key reduction and curve fitting algorithms.
+Surprisingly, it is quite common for compression algorithms to use local space instead. Error is measured using linear key reduction and curve fitting algorithms.
 
 # Approximating the Visual Error
-
-Since our skeleton is generally never directly visible, any error will be visible on the visual mesh instead. This means the most accurate way to measure any error would be to perform skinning for every key frame and comparing every vertex before and after compression.
+Since a skeleton is generally never directly visible errors are visible on the visual mesh instead. This means the most accurate way to measure errors is to perform skinning for every keyframe and comparing vertices before and after compression.
 
 Sadly, this would be terribly slow even with help from the GPU in many instances.
 
-Instead, we can use virtual or fake vertices at a fixed distance from each bone. This is both intuitive and easy to achieve: for every object space bone transform, we simply apply the transform to a local vertex position. For example, I can use a vertex in local space of a bone at a fixed offset of say 10cm, and by applying the object space bone transform, my vertex will end up in object space. This step is done both with the source animation and the compressed animation and we can then compare the distance between the two transformed vertices to measure our error.
+Instead, we can use virtual or fake vertices at a fixed distance from each bone. This is both intuitive and easy to achieve: for every object space bone transform we simply apply the transform to a local vertex position. For example, a vertex in local space of a bone at a fixed offset of 10cm will end up in object space with the object space bone transform applied. This step is done with both the source animation and the compressed animation so we can compare the distance between the two transformed vertices to measure error.
 
-Note that we need to use two virtual vertices per bone and they must be orthogonal to each-other. Otherwise, if our single vertex happens to be co-linear with the bone rotation axis, the error could end up being less visible or entirely invisible. For this reason, two vertices are used and the maximum error delta can be used. In practice, you would use something like `vec3(0, 0, distance)` and `vec3(0, distance, 0)`.
+For this to work we need to use two virtual vertices per bone and they must be orthogonal to each other. Otherwise, if our single vertex happens to be co-linear with the bone’s rotation axis, the error could end up being less visible or entirely invisible. For this reason, two vertices are used with the maximum error delta. In practice, we would use something like `vec3(0, 0, distance)` and `vec3(0, distance, 0)`.
 
 This properly takes into account all three bone tracks and it approximately takes into account the fact that the visual mesh is always some distance away from the skeleton.
 
-Which virtual distance you use is important: if it is much smaller than the distance of real vertices, the error might end up being visible (since error increases with distance for rotation and scale), and if the distance is much larger, we might end up retaining more accuracy than we otherwise need.
+Which virtual distance you use is important. A virtual distance much smaller than the distance of real vertices the error might end up being visible since error increases with distance for rotation and scale. If the distance is much larger we might end up retaining more accuracy than we otherwise need.
 
-For most character bones, a distance in the range of 2-10cm makes sense. Special bones such as the root and camera might require higher accuracy and as such should probably use a higher distance in the range of 1-10m.
+For most character bones a distance in the range of 2-10cm makes sense. Special bones like the root and camera might require higher accuracy and as such should probably use a distance closer to 1-10m.
 
-It is also common for certain large animated objects to have distances larger than 1-10m between a vertex and the bone it is skinned on. As such these objects either need extra bones added to reduce that maximum distance or the virtual distance needs to be adjusted correspondingly.
+Large animated objects also occasionally benefit from vertex to bone distances of 1-10m and either need extra bones added to reduce maximum distance, or the virtual distance needs to be adjusted correspondingly.
 
-Note that you could probably extract the furthest skinned vertex per bone from the visual mesh and use that instead but do keep in mind some bones might not have skinned vertices such as the root and camera bones.
+It’s also worth mentioning that we could probably extract the furthest skinned vertex per bone from the visual mesh and use that instead but keep in mind some bones might not have skinned vertices such as the root and camera bones.
 
 # Conclusion
+Accuracy is modified using a single intuitive number, the virtual vertex distance and is measured with a single value, object space distance.
 
-Our accuracy is tweaked with a single intuitive number (the virtual vertex distance) and it is measured with a single simple value: an object space distance. These are generally easy to understand and reason about.
+Both Unity and Unreal measure accuracy in ways that are sub-optimal and fail to take into account all three properties outlined above. From what I have seen their techniques are also representative of a lot of game engines out there. Future posts will explore the solutions those game engines provide.
 
-Both Unity and Unreal measure accuracy in ways that are sub-optimal and fail to take into account all three properties we outlined above. From what I have seen, their techniques are also representative of a lot of game engines out there. Future posts will explore the solutions those game engines provide.
+A number of compression algorithms use the error metric function to attempt to converge on a solution like linear key reduction, for example. If metrics are imprecise or poorly represent true error it is very likely that will be reflected in the end result. Many linear key reduction algorithms use local space error metric which sometimes leads to important keys being removed from distant children of the point of error. For example, a pelvis key being removed can translate into a large error at the fingertip. The typical way to combat this side-effect is to trend the local error metric such even more conservatively until desired keys are retained but this translates directly to the memory footprint increasing.
 
-A number of compression algorithms will use the error metric function to attempt to converge to a solution (e.g. linear key reduction). As such, if the metric is imprecise or poorly represents the true error, it is very likely that the end result will be poor. And indeed, in my experience, many linear key reduction algorithms out there use a local space error metric which can and sometimes leads to important keys being removed where the error accrued on the distant children is unacceptable (e.g. a pelvis key being removed can translate into a large error at the fingertip). The typical way to combat this side-effect is to tweak the local error metric such that it becomes even more conservative and ends up retaining the desired key. This translates directly in the memory footprint increasing.
 
 [Up next: Constant Tracks]({% post_url 2016-11-03-anim_compression_constant_tracks %})
 
 [**Back to table of contents**]({% post_url 2016-10-21-anim_compression_toc %})
-

--- a/_posts/2016-12-19-anim_compression_signal_processing.md
+++ b/_posts/2016-12-19-anim_compression_signal_processing.md
@@ -2,110 +2,95 @@
 layout: post
 title: "Animation Compression: Signal Processing"
 ---
-Algorithm variants in the [signal processing](https://en.wikipedia.org/wiki/Signal_processing) category can take many forms but the most common and popular approach is to use [Wavelets](https://en.wikipedia.org/wiki/Wavelet). As such, we will only cover that particular flavour and I happen to know a decent amount about it having implemented it once in the past for [Thief (2014)](https://en.wikipedia.org/wiki/Thief_(2014_video_game)) (which used it extensively for all its character animation clips on all supported platforms).
+[Signal processing](https://en.wikipedia.org/wiki/Signal_processing) algorithm variants come in many forms but the most common and popular approach is to use [Wavelets](https://en.wikipedia.org/wiki/Wavelet). Having utilized this method for all character animation clips on all supported platforms for [Thief (2014)](https://en.wikipedia.org/wiki/Thief_(2014_video_game)) I have a fair amount to share with you.
 
-Other variants of this family might rely on these various techniques:
+Other signal processing algorithm variants include [Discrete Cosine Transform](https://en.wikipedia.org/wiki/Discrete_cosine_transform), [Principal Component Analysis](https://en.wikipedia.org/wiki/Principal_component_analysis), and [Principal Geodesic Analysis](https://en.wikipedia.org/wiki/Principal_geodesic_analysis).
 
-*  [Discrete cosine transform](https://en.wikipedia.org/wiki/Discrete_cosine_transform)
-*  [Principal component analysis](https://en.wikipedia.org/wiki/Principal_component_analysis)
-*  [Principal geodesic analysis](https://en.wikipedia.org/wiki/Principal_geodesic_analysis)
-
-It is worth mentioning that the last two flavours are also commonly used alongside clustering and database approaches. If there is interest, I might detail those further at some point.
+The latter two variants are commonly used alongside clustering and database approaches which I’ll explore if enough interest is expressed but I’ll be focusing on [Wavelets](https://en.wikipedia.org/wiki/Wavelet) here.
 
 # How It Works
+At their core implementations that leverage wavelets for compression will be split into four distinct steps:
 
-At their core, implementations that leverage wavelets for compression will be split into four discreet steps:
+*   Pre-processing
+*   The wavelet transform
+*   Quantization
+*   Entropy coding
 
-*  Pre-processing
-*  The wavelet transform
-*  Quantization
-*  Entropy coding
-
-The flow of information is illustrated as follow:
+The flow of information can be illustrated like this:
 
 ![Wavelet Algorithm Layout](/public/wavelet_compression_process.jpg)
 
-The most important step is of course the wavelet function around which everything is centred. We will thus cover it first before the other steps which will help clarify their purpose.
+The most important step is, of course, the wavelet function, around which everything is centered. Covering wavelet function first will help clarify the purpose of every other step.
 
-It is worth noting that aside from quantization, all the steps involved are effectively lossless (they only suffer from some minor floating point rounding). As such, by altering how many bits we use for the quantization step, we can control how aggressive we want to be with our compression.
+Aside from quantization all of the steps involved are effectively lossless and only suffer from minor floating point rounding. By altering how many bits we use for the quantization step we can control how aggressive we want to be with compression.
 
-The decompression is simply the reverse process of each individual step, each performed in reverse order.
+The decompression is simply the same process of steps performed in reverse order.
 
-## Wavelet Basics
+# Wavelet Basics
+We will avoid going too in depth on this topic in this series instead of focusing on discussing the wavelet properties and what they mean for us with respect to character animation and compression in general. A good starting point for the curious would be the [Haar wavelet](https://en.wikipedia.org/wiki/Haar_wavelet) which is the simplest of wavelet functions, however, it’s generally avoided for compression.
 
-Sadly, going in depth on this topic is out of scope for this series and I am not entirely sure whether or not I am qualified to teach such material. Here, we will only discuss the wavelet properties and what it means for us with respect to character animation and compression in general.
-
-The simplest wavelet function is by far the [Haar wavelet](https://en.wikipedia.org/wiki/Haar_wavelet) but you should not use it for compression. However, it should serve as a good starting point for the topic if you are curious.
-
-By definition, wavelet functions are recursive: each application of the function is referred as a sub-band and will output an equal number of scale and coefficient values (each exactly half the original input size), and in turn we will recursively apply the function on the resulting scale values of the previous sub-band. The end result is a single scale value and `N - 1` coefficients where `N` is the input size.
+By definition wavelet functions are recursive. Each application of the function is referred to as a sub-band and will output an equal number of scale and coefficient values each exactly half the original input size. In turn, we can recursively apply the function on the resulting scale values of the previous sub-band. The end result is a single scale value and `N - 1` coefficients where `N` is the input size.
 
 ![Recursive Wavelet](/public/wavelet_recursive_1d.png)
 
-For the [Haar wavelet](https://en.wikipedia.org/wiki/Haar_wavelet), the scale is simply the sum of two input values, and the coefficient is their difference. As far as I know, most wavelet functions will function similarly which yields coefficients that are as close to zero as possible (and exactly zero for a constant input signal).
+[Haar wavelet](https://en.wikipedia.org/wiki/Haar_wavelet) scale is simply the sum of two input values and the coefficient represents their difference. As far as I know most wavelet functions function similarly which yield coefficients that are as close to zero as possible and exactly zero for a constant input signal.
 
-The [Haar wavelet](https://en.wikipedia.org/wiki/Haar_wavelet) is not suitable for compression because it has a single vanishing moment. What this means is that the input data is processed in pairs, each outputting a single scale and a single coefficient. However the pairs never overlap which means that if there is a discontinuity in between two pairs, it will not be taken into account yielding undesirable artifacts if the coefficients are not accurate (and as we will see later, we will quantize them). As such a decent alternative is to use something like a [Daubechies D4 wavelet](https://en.wikipedia.org/wiki/Daubechies_wavelet). This is the function I used on [Thief](https://en.wikipedia.org/wiki/Thief_(2014_video_game)) and it turned out quite decent for our purposes. Note that a number of academic papers I found on the subject failed to document which wavelet function they used, a grave mistake...
+The reason [Haar wavelet](https://en.wikipedia.org/wiki/Haar_wavelet) are not suitable for compression because it has a single vanishing moment. This means input data is processed in pairs, each outputting a single scale and a single coefficient. The pairs never overlap which means that if there is a discontinuity in between two pairs it will not be taken into account and yield undesirable artifacts if the coefficients are not accurate. A decent alternative is to use a [Daubechies D4 wavelet](https://en.wikipedia.org/wiki/Daubechies_wavelet). This is the function I used on [Thief(2014)](https://en.wikipedia.org/wiki/Thief_(2014_video_game)) and it turned out quite decently for our purposes.
 
-The wavelet transform can be entirely lossless by using an integer variant but in practice we can simply use an ordinary floating point variant since our compression is lossy by nature and the rounding will not measurably impact the results.
+The wavelet transform can be entirely lossless by using an integer variant but in practice, an ordinary floating point variant is appropriate since compression is lossy by nature and the rounding will not measurably impact the results.
 
-Since the wavelet function decomposes the signal into an [orthonormal basis](https://en.wikipedia.org/wiki/Orthonormal_basis), we will be able to achieve the highest compression by considering as much of the signal as possible (not unlike [principal component analysis](https://en.wikipedia.org/wiki/Principal_component_analysis)). As such we can simply concatenate all our tracks together into a single 1D signal. The up side of this is that by considering all the data as a whole, we can find a single [orthonormal basis](https://en.wikipedia.org/wiki/Orthonormal_basis) which will allow us to quantize more aggressively but by having a larger signal to transform, the decompression speed will suffer. In practice to keep it reasonably fast on modern hardware, each track would likely be processed independently in a small power of two such at 16 keys at a time. For [Thief](https://en.wikipedia.org/wiki/Thief_(2014_video_game)), all rotation tracks and translation tracks were aggregated independently (we ran the wavelet transform once for rotation tracks, and once for translation tracks) up to a maximum segment size of **64 KB**.
+Since wavelet function decomposes a signal on an [orthonormal basis](https://en.wikipedia.org/wiki/Orthonormal_basis) we will be able to achieve the highest compression by considering as much of the signal as possible not unlike [principal component analysis](https://en.wikipedia.org/wiki/Principal_component_analysis). Simply concatenate all tracks together into a single 1D signal. The upside of this is that by considering all data as a whole we can find a single [orthonormal basis](https://en.wikipedia.org/wiki/Orthonormal_basis) which will allow us to quantize more aggressively but by having a larger signal to transform the decompression speed will suffer. To keep the process reasonably fast in practice on modern hardware each track would likely be processed independently in a small power of two, such as 16 keys at a time. For [Thief(2014)](https://en.wikipedia.org/wiki/Thief_(2014_video_game)), all rotation tracks and translation tracks were aggregated independently up to a maximum segment size of 64 KB. We ran the wavelet transform once for rotation tracks, and once for translation tracks.
 
-## Pre-processing
+# Pre-processing
+Because wavelet functions are recursive the size of the input data needs to be a power of two. If our size doesn’t match we will need to introduce some form of padding:
+*   Pad with zeroes
+*   Repeat the last value
+*   Mirror the signal
+*   Loop the signal
+*   Something even more creative?
 
-Because wavelet functions are recursive, the size of the input data needs to be a power of two. If our size doesn’t match, we will need to introduce some form of padding:
+Which padding approach you choose is likely to have a fairly minimal impact on compression is worth measuring. Your guess is as good as mine regarding which is best. In practice, it’s best to avoid padding as much as possible by keeping input sizes fairly small and processing the input data in blocks or segments.
 
-*  Pad with zeroes
-*  Repeat the last value
-*  Mirror the signal
-*  Loop the signal
-*  Maybe something even more creative?
+The scale of output coefficients is a function of the scale and smoothness of our input values. As such it makes sense to perform [range reduction](http://nfrechette.github.io/2016/11/09/anim_compression_range_reduction/) and to normalize our input values.
 
-Which approach you choose for padding is likely to have a fairly minimal impact on compression but it might still be measurable. Your guess is as good as mine regarding which is best. In practice, we will always try to avoid padding as much as possible by keeping our input size fairly small and by processing the input data in blocks or segments.
+# Quantization
+After applying the wavelet transform the number of output values will match the number of input values. No compression has happened yet.
 
-The scale of the output coefficients are a function of the scale and smoothness of our input values. As such it makes sense to perform [range reduction]({% post_url 2016-11-09-anim_compression_range_reduction %}) and to normalize our input values.
+As mentioned previously our output values will be partitioned into sub-bands, and a single scale value somewhat centered around zero — both positive and negative. Each sub-band will end up with a different range of values. Larger sub-bands resulting from the first applications of the wavelet function will be filled with high-frequency information while the smaller sub-bands will comprise the low-frequency information. This is important. It means that a single low-frequency coefficient will impact a larger range of values after performing the inverse wavelet transform. Because of this low-frequency coefficients need higher accuracy than high-frequency coefficients.
 
-## Quantization
+To achieve compression we will quantize our coefficients into a reduced number of bits while keeping the single scale value with full precision. Due to the nature of the data, we will perform range reduction per sub-band and normalize our values between `[-1.0, 1.0]`. We only need to keep the range extent for reconstruction and simply assume that the range is centered around zero. Quantization might not make sense for the lower frequency sub-bands with 1, 2, 4 coefficients due to the extra overhead of the range extent. Once our values are normalized we can quantize them. To choose how many bits to use per coefficient we can simply hard code a high number such as 16 bits, 12 bits, or alternatively experiment with values in an attempt to optimize a solution to meet an error threshold. Quantization could also be performed globally to reduce the range of information overhead instead of per sub-band depending on the number of input values being processed. For example processing 16 keys at a time.
 
-After applying the wavelet transform, the number of output values will match the number of input values. No compression has happened yet.
+# Entropy Coding
+In order to be competitive with other techniques, we need to push compression further using [entropy coding](https://en.wikipedia.org/wiki/Entropy_encoding) which is an entirely lossless compression step.
 
-As we mentioned previously, our output values will be partitioned into sub-bands (and a single scale value) and be somewhat centred around zero (both positive and negative). Each sub-band will end up with a different range of values: larger sub-bands (the first applications of the wavelet function) will be filled with high frequency information while the smaller sub-bands will comprise the low frequency information. This is important, it means that a single low frequency coefficient will impact a larger range of values after performing the inverse wavelet transform. As such, low frequency coefficients need higher accuracy than high frequency coefficients.
+After quantization we obtain a number of integer values on a single scale all centered around zero. The most obvious thing that we can compress now is the fact that we have very few large values. To leverage this we apply a [zigzag transform](https://wiki.multimedia.cx/index.php/Zigzag_Reordering) on our data, mapping negative integers to positive unsigned integers such that values closest to zero remain closest to zero. This transforms our data in such a way that we still end up with very few large values which are significant because it means that most of our values represented in memory now have many leading zeroes.
 
-To achieve compression, we will quantize our coefficients (and keep the single scale value with full precision) into a reduced number of bits. Due to the nature of the data, we will perform range reduction per sub-band and normalize our values between `[-1.0, 1.0]`. We only need to keep the range extent for reconstruction and simply assume that the range is centred around zero. For the lower frequency sub-bands, with 1, 2, 4 coefficients, quantization might not make sense due to the extra overhead of the range extent. Once our values are normalized, we can quantize them. To chose how many bits to use per coefficient, we can simply hardcode a high number such as **16** bits or **12** bits, or alternatively we can try various values and attempt to optimize towards an optimal solution to meet some error threshold. Depending on the number of input values that we process, quantization could also be performed globally instead of per sub-band (e.g. processing 16 keys at a time) reducing the range information overhead.
+For example suppose we quantize everything onto 16 bit signed integers: `-50, 50, 32760`. In memory these values are represented with [twos complement](https://en.wikipedia.org/wiki/Two's_complement): `0xFFCE, 0x0032, 0x7FF8`. This is not great and how to compress this further is not immediately obvious. If we apply the [zigzag transform](https://wiki.multimedia.cx/index.php/Zigzag_Reordering) and map our signed integers into unsigned integers: `100, 99, 65519`. In memory these unsigned integers are now represented as: `0x0064, 0x0063, 0xFFEF`. An easily predictable pattern emerges with smaller values with a lot of leading zeroes which will compress well.
 
-## Entropy Coding
+At this point, a generic entropy coding algorithm is used like [zlib](https://en.wikipedia.org/wiki/Zlib), [Huffman](https://en.wikipedia.org/wiki/Huffman_coding), or some custom [arithmetic coding algorithm](https://en.wikipedia.org/wiki/Arithmetic_coding). Luke Mamacos gives a [decent example](https://worldoffries.wordpress.com/2015/08/25/simple-entropy-coder/) of a wavelet arithmetic encoder that takes advantage of leading zeros.
 
-If we wish to push compression further (and we need to in order to be competitive with the other techniques), we need to perform [entropy coding](https://en.wikipedia.org/wiki/Entropy_encoding). This compression step is entirely lossless.
-
-After our quantization phase, we obtain a number of integer values centred around zero (and a single scale). The most obvious thing that we can compress now is the fact that we have very few large values. To leverage this, we apply a [zigzag transform](https://wiki.multimedia.cx/index.php/Zigzag_Reordering) on our data, mapping negative integers to positive unsigned integers such that values closest to zero remain closest to zero. This transforms our data in such a way that we still end up with very few large values. This is significant because it means that most of our values now have many leading zeroes in their representation in memory.
-
-For example, suppose we quantize everything onto **16** bit signed integers: `-50, 50, 32760`. In memory, these values are represented with [twos complement](https://en.wikipedia.org/wiki/Two's_complement): `0xFFCE, 0x0032, 0x7FF8`. This is not great and how to compress this further is not immediately obvious. Now we apply the [zigzag transform](https://wiki.multimedia.cx/index.php/Zigzag_Reordering) and map our signed integers into unsigned integers: `100, 99, 65519`. In memory, these unsigned integers are now represented as: `0x0064, 0x0063, 0xFFEF`. It is now obvious that smaller values have a lot of leading zeros and thus an easily predictable pattern has emerged which will compress well.
-
-At this point, a generic entropy coding algorithm is used: [zlib](https://en.wikipedia.org/wiki/Zlib), [Huffman](https://en.wikipedia.org/wiki/Huffman_coding), or some custom [arithmetic coding algorithm](https://en.wikipedia.org/wiki/Arithmetic_coding). Luke Mamacos gives a decent example [here](https://worldoffries.wordpress.com/2015/08/25/simple-entropy-coder/) of a wavelet arithmetic encoder that takes advantage of the leading zeros.
-
-Note that if you process a very large input in a single block, you will likely end up with lots of padding at the end which will typically end up as all zero values after the quantization step. It can be a win to use [run length encoding](https://en.wikipedia.org/wiki/Run-length_encoding) to compress those as well before the entropy coding phase.
+It’s worth noting that if you process a very large input in a single block you will likely end up with lots of padding at the end. This typically ends up as all zero values after the quantization step and it can be beneficial to use [run length encoding](https://en.wikipedia.org/wiki/Run-length_encoding) to compress those before the entropy coding phase.
 
 # In The Wild
+Signal processing algorithms tend to be the most complex to understand while requiring the most code. This makes maintenance a challenge which is represented by a decreased use in the wild.
 
-As will be made obvious by the length of this post, signal processing algorithms will tend to be the most complex in terms of understanding what happens as well as having the most code involved. This makes their maintenance and usage less popular which is why they aren’t all that common in the wild.
+While these compression methods can be used competitively if the right entropy coding algorithm is used, they tend to be far too slow to decompress, too complex to implement, and too challenging maintain for the results that they yield.
 
-While it can be used and the compression can be competitive if the right entropy coding algorithm is used, they tend to be far too slow to decompress and too complex to implement and maintain for the results that they give.
-
-That being said, on [Thief](https://en.wikipedia.org/wiki/Thief_(2014_video_game)), I implemented a wavelet compression algorithm (they were all the rage at the time) to replace the [linear key reduction]({% post_url 2016-12-07-anim_compression_key_reduction %}) algorithm used in [Unreal 3](https://en.wikipedia.org/wiki/Unreal_Engine#Unreal_Engine_3). The [linear key reduction]({% post_url 2016-12-07-anim_compression_key_reduction %}) algorithm was very hard to tweak properly due to a naive error function it used which resulted in a large memory footprint or inaccurate animation clips. The wavelet implementation ended up being faster to compress with and yielded a smaller memory footprint with good accuracy.
+Due to its popularity at the time I introduced wavelet compression to [Thief(2014)](https://en.wikipedia.org/wiki/Thief_(2014_video_game)) to replace the [linear key reduction](http://nfrechette.github.io/2016/12/07/anim_compression_key_reduction/) algorithm used in [Unreal 3](https://en.wikipedia.org/wiki/Unreal_Engine#Unreal_Engine_3). [Linear key reduction](http://nfrechette.github.io/2016/12/07/anim_compression_key_reduction/) was very hard to tweak properly due to a naive error function it used resulting in a large memory footprint or inaccurate animation clips. The wavelet implementation ended up being faster to compress with and yielded a smaller memory footprint with good accuracy.
 
 # Performance
+Fundamentally the wavelet decomposition allows us to exploit temporal coherence in our animation clip data, but this comes at a price. In order to sample a single keyframe, we must reverse everything. Meaning, if we process 16 keys at a time we must decompress our 16 keys to sample a single one of them (or two if we linearly interpolate as we normally would when sampling our clip). For this reason, wavelet implementations are terribly slow to decompress and speeds end up not being competitive at all which only gets worse as you process a larger input signal. On [Thief(2014)](https://en.wikipedia.org/wiki/Thief_(2014_video_game)) full decompression on the [Play Station 3](https://en.wikipedia.org/wiki/PlayStation_3) [SPU](https://en.wikipedia.org/wiki/Cell_(microprocessor)#Synergistic_Processing_Elements_.28SPE.29) took between **800us** and **1300us** for blocks of data up to 64 KB.
 
-Fundamentally, the wavelet decomposition allows us to exploit temporal coherence in our animation clip data. But this comes at a price. In order to sample a single key frame, we must reverse everything, meaning if we process 16 keys at a time, we must decompress our 16 keys to sample a single one of them (or two if we linearly interpolate as we normally would when sampling our clip). For this reason wavelet implementations are terribly slow to decompress and end up not being competitive at all, speed wise. This of course only gets worse as you process a larger input signal. On [Thief](https://en.wikipedia.org/wiki/Thief_(2014_video_game)), full decompression on the [Play Station 3](https://en.wikipedia.org/wiki/PlayStation_3) [SPU](https://en.wikipedia.org/wiki/Cell_(microprocessor)#Synergistic_Processing_Elements_.28SPE.29) took between **800us** and **1300us** for blocks of data up to **64 KB**.
+Obviously, this is entirely unacceptable with other techniques in the range of **30us** and **200us**. To mitigate this and keep it competitive an intermediate cache is necessary.
 
-Obviously, this is entirely unacceptable (with other techniques likely in the range of **30us** and **200us**). To mitigate this and keep it competitive, an intermediate cache is necessary.
+The idea of the cache is to perform the expensive decompression once for a block of data (e.g. 16 keys) and re-use it in the future. At 30 FPS our 16 keys will be usable for roughly 0.5 seconds. This, of course, comes with a cost as we now need to implement and maintain an entirely new layer of complexity. We must first decompress into the cache and then interpolate our keys from it. The decompression can typically be launched early to avoid stalls when interpolating but it is not always possible. This is particularly problematic on the first frame of gameplay where a large number of animations will start to play at the same time while our cache is empty or stale. For similar reasons, the same issue happens when a cinematic moment starts or any moment in gameplay with major or abrupt change.
 
-The idea of the cache is to perform the expensive decompression once for a block of data (e.g. 16 keys) and re-use it in the future. At 30 FPS, our 16 keys will be usable for roughly 0.5 seconds. This is of course not free as we now need to implement and maintain an entire new layer of complexity. We must first decompress into the cache, and then interpolate our keys from it. The decompression can typically be launched early as to avoid stalls when interpolating but it is not always possible to do this. This is particularly problematic on the first frame of gameplay where a large number of animations will start to play at the same time while our cache is empty or stale. For similar reasons, the same issue happens when a cinematic moment starts or any major abrupt change in gameplay.
+On the upside, as we decompress only once into the cache we can also take a bit of time to swizzle our data and sort it by key and bone such that our data per key frame is now contiguous. Sampling from our cache then becomes more or less equivalent to sampling with [simple quantization](http://nfrechette.github.io/2016/11/15/anim_compression_quantization/). For this reason sampling from the cache is extremely fast and competitive (as fast as [simple quantization](http://nfrechette.github.io/2016/11/15/anim_compression_quantization/)).
 
-On the up side, as we decompress only once into the cache, we can also take a bit of time to swizzle our data and sort it by key and bone such that our data per key frame is now contiguous. Sampling from our cache then becomes more or less equivalent to sampling with [simple quantization]({% post_url 2016-11-15-anim_compression_quantization %}). For this reason, sampling from the cache is extremely fast and competitive (as fast as [simple quantization]({% post_url 2016-11-15-anim_compression_quantization %})).
+Our small cache for [Thief(2014)](https://en.wikipedia.org/wiki/Thief_(2014_video_game)) was held in main memory while our wavelet compressed data was held in video memory on the [Play Station 3](https://en.wikipedia.org/wiki/PlayStation_3). This played very well in our favor with the rare decompressions not impacting the rendering bandwidth as much and keeping interpolation fast. This also contributed to slower decompression times but it was still faster than it was on the [Xbox 360](https://en.wikipedia.org/wiki/Xbox_360).
 
-On [Thief](https://en.wikipedia.org/wiki/Thief_(2014_video_game)), our small cache was held in main memory while our wavelet compressed data was held in video memory on the [Play Station 3](https://en.wikipedia.org/wiki/PlayStation_3). This played very well in our favour with the rare decompressions not impacting the rendering bandwidth as much and keeping interpolation fast. This also contributed to slower decompression times but it was still faster than it was on the [Xbox 360](https://en.wikipedia.org/wiki/Xbox_360).
-
-As is now obvious, the signal processing algorithms should be avoided in favour of simpler algorithms that are easier to implement, maintain, and end up just as competitive when properly implemented.
+In conclusion signal processing algorithms should be avoided in favor of simpler algorithms that are easier to implement, maintain, and end up just as competitive when properly implemented.
 
 [Up next: Error Compensation]({% post_url 2016-12-22-anim_compression_error_compensation %})
 
 [**Back to table of contents**]({% post_url 2016-10-21-anim_compression_toc %})
-

--- a/_posts/2017-01-11-anim_compression_unreal4.md
+++ b/_posts/2017-01-11-anim_compression_unreal4.md
@@ -2,102 +2,92 @@
 layout: post
 title: "Animation Compression: Unreal 4"
 ---
-[Unreal 4](https://en.wikipedia.org/wiki/Unreal_Engine#Unreal_Engine_4) offers a wide range of character animation compression settings. The main documentation page for it lives [here](https://docs.unrealengine.com/latest/INT/Engine/Animation/Sequences/).
+[![Unreal 4 2017](https://img.youtube.com/vi/WC6Xx_jLXmg/0.jpg)](https://www.youtube.com/watch?v=WC6Xx_jLXmg "Unrael 4 2017")
+
+[Unreal 4](https://en.wikipedia.org/wiki/Unreal_Engine#Unreal_Engine_4) offers a wide range of [documented](https://docs.unrealengine.com/latest/INT/Engine/Animation/Sequences/) character animation compression settings.
 
 It offers the following compression algorithms:
+*   [Least Destructive](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#least_destructive)
+*   [Remove Every Second Key](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#second_key)
+*   [Remove Trivial Keys](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#trivial_keys)
+*   [Bitwise Compress Only](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#bitwise_only)
+*   [Remove Linear Keys](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#remove_linear)
+*   [Compress each track independently](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#compress_independently)
+*   [Automatic](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#automatic_setting)
 
-*  [Least Destructive](#least_destructive)
-*  [Remove Every Second Key](#second_key)
-*  [Remove Trivial Keys](#trivial_keys)
-*  [Bitwise Compress Only](#bitwise_only)
-*  [Remove Linear Keys](#remove_linear)
-*  [Compress each track independently](#compress_independently)
-*  [Automatic](#automatic_setting)
-
-## <a name="least_destructive"></a>Least Destructive
-
+## Least Destructive
 >  Reverts any animation compression, restoring the animation to the raw data.
 
-This setting ensures we use raw data. It sets all tracks to use no compression which means they will have full floating point precision (**None** is used for translation and **Float 96** for rotation, see [below](#bitwise_only)). Interestingly, it does not appear to revert the scale to a sensible default raw compression setting. This is likely a bug.
+This setting ensures we use raw data. It sets all tracks to use no compression which means they will have full floating point precision where **None** is used for translation and **Float 96** for rotation, explained [below](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#bitwise_only). Interestingly it does not appear to revert the scale to a sensible default raw compression setting which is likely a bug.
 
-## <a name="second_key"></a>Remove Every Second Key
-
+## Remove Every Second Key
 >  Keyframe reduction algorithm that simply removes every second key.
 
-This setting does exactly what it claims: it removes every other key. It is a variation of [sub-sampling]({% post_url 2016-11-17-anim_compression_sub_sampling %}). Each remaining key is further [bitwise compressed](#bitwise_only).
+This setting does exactly what it claims; it removes every other key. It is a variation of [sub-sampling](http://nfrechette.github.io/2016/11/17/anim_compression_sub_sampling/). Each remaining key is further [bitwise compressed](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#bitwise_only).
 
-Note that this compression setting also removes the [trivial keys](#trivial_keys).
+Note that this compression setting also removes the [trivial keys](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#trivial_keys).
 
-## <a name="trivial_keys"></a>Remove Trivial Keys
-
+## Remove Trivial Keys
 >  Removes trivial frames of tracks when position or orientation is constant over the entire animation from the raw animation data.
 
-This takes advantage of the fact that very often, [tracks are constant]({% post_url 2016-11-03-anim_compression_constant_tracks %}) and when it happens, a single key is kept and the rest is discarded.
+This takes advantage of the fact that very often [tracks are constant](http://nfrechette.github.io/2016/11/03/anim_compression_constant_tracks/) and when it happens a single key is kept and the rest is discarded.
 
-## <a name="bitwise_only"></a>Bitwise Compress Only
-
+## Bitwise Compress Only
 >  Bitwise animation compression only; performs no key reduction.
 
-This compression setting aims to retain every single key and encodes them with various variations. It is a custom flavour of [simple quantization]({% post_url 2016-11-15-anim_compression_quantization %}). It will use the same format for every track in the clip. You can select one format per track type: rotation, translation, and scale.
+This compression setting aims to retain every single key and encodes them with various variations. It is a custom flavor of [simple quantization](http://nfrechette.github.io/2016/11/15/anim_compression_quantization/) and will use the same format for every track in the clip. You can select one format per track type: rotation, translation, and scale.
 
 These are the possible formats:
+*   **None:** Full precision.
+*   **Float 96:** Full precision is used for translation and scale. For rotations, a quaternion component is dropped and the rest are stored with full precision.
+*   **Fixed 48:** For rotations, a quaternion component is dropped and the rest is stored on **16** bits per component.
+*   **Interval Fixed 32:** Stores the value on **11-11-10** bits per component with range reduction. For rotations, a quaternion component is dropped.
+*   **Fixed 32:** For rotations, a quaternion component is dropped and the rest is stored on **11-11-10** bits per component.
+*   **Float 32:** This appears to be a semi-deprecated format where a quaternion component is dropped and the rest is encoded onto a custom float format with **6** or **7** bits for the mantissa and **3** bits for the exponent.
+*   **Identity:** The identity quaternion is always returned for the rotation track.
 
-*  **None:** Full precision.
-*  **Float 96:** For translation and scale, full precision is used. For rotations, a quaternion component is dropped and the rest are stored with full precision.
-*  **Fixed 48:** For rotations, a quaternion component is dropped and the rest is stored on **16** bits per component.
-*  **Interval Fixed 32:** Stores the value on **11-11-10** bits per component with range reduction (for rotations, a quaternion component is dropped).
-*  **Fixed 32:** For rotations, a quaternion component is dropped and the rest is stored on **11-11-10** bits per component.
-*  **Float 32:** This appears to be a semi-deprecated format where a quaternion component is dropped and the rest is encoded onto a custom float format with **6** or **7** bits for the mantissa and **3** bits for the exponent.
-*  **Identity:** For rotations, the identity quaternion is always returned for this track.
+Only three formats are supported for translation and scale: **None, Interval Fixed 32**, and **Float 96**. All formats are supported for rotations.
 
-Only three formats are supported for translation and scale: **None**, **Interval Fixed 32**, and **Float 96**. All formats are supported for rotations.
+If a track has a single key it is always stored with full precision.
 
-If a track has a single key, it is always stored with full precision.
+When a component is dropped from a rotation quaternion, **W** is always selected. This is safe and simple since it can be reconstructed with a square root as long as our quaternion is normalized. The sign is forced to be positive during compression by negating the quaternion if **W** was originally negative. A quaternion and its negated opposite [represent the same rotation on the hypersphere](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#The_hypersphere_of_rotations).
 
-For rotation quaternions, when a component is dropped, **W** is always selected. This is safe and simple since it can be reconstructed with a square root as long as our quaternion is normalized. The sign is forced to be positive during compression by negating the quaternion if **W** was originally negative. A quaternion and its negated opposite [represent the same rotation on the hypersphere](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#The_hypersphere_of_rotations).
+Sadly, the selection of which format to use is done manually and no heuristic is used to perform some automatic selection with this setting.
 
-Sadly the selection of which format to use is done manually and no heuristic is used to perform some automatic selection with this setting.
+Note that this compression setting also removes the [trivial keys](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#trivial_keys).
 
-Note that this compression setting also removes the [trivial keys](#trivial_keys).
-
-## <a name="remove_linear"></a>Remove Linear Keys
-
+## Remove Linear Keys
 >  Keyframe reduction algorithm that simply removes keys which are linear interpolations of surrounding keys.
 
-This is a classic variation on [linear key reduction]({% post_url 2016-12-07-anim_compression_key_reduction %}) with a few interesting twists.
+This is a classic variation on [linear key reduction](http://nfrechette.github.io/2016/12/07/anim_compression_key_reduction/) with a few interesting twists.
 
-They use a local space [error metric]({% post_url 2016-11-01-anim_compression_accuracy %}) coupled with a partial virtual vertex [error metric]({% post_url 2016-11-01-anim_compression_accuracy %}). The local space metric is used classically to reject key removal beyond some error threshold. On the other hand, they check the impacted end effector (e.g. leaf) bones that are children of a given track. To do so, a virtual vertex is used but no attempt is made to ensure it isn’t co-linear with the rotation axis. Bones in between the two bones (the one being modified and the leaf) are not checked at all and should they end up with unacceptable error, it will be invisible and not accounted for by the metric.
+They use a [local space error metric coupled with a partial virtual vertex error metric](http://nfrechette.github.io/2016/11/01/anim_compression_accuracy/). The local space metric is used classically to reject key removal beyond some error threshold. On the other hand, they check the impacted end effector (e.g. leaf) bones that are children of a given track. To do so a virtual vertex is used but no attempt is made to ensure it isn’t co-linear with the rotation axis. Bones in between the two bones (the one being modified and the leaf) are not checked at all and should they end up with unacceptable error, it will be invisible and not accounted for by the metric.
 
 There is also a bias applied on tracks to attempt to remove similar keys on children and their parent bone tracks. I’m not entirely certain why they would opt to do this but I doubt it can harm the results.
 
-On the decompression side, no cursor or acceleration structure is used meaning that each time we sample the clip, we will need to search for which keys to interpolate between and we do so per track.
+On the decompression side no cursor or acceleration structure is used; meaning that each time we sample the clip we will need to search for which keys to interpolate between and we do so per track.
 
-Note that this compression setting also removes the [trivial keys](#trivial_keys).
+Note that this compression setting also removes the [trivial keys](http://nfrechette.github.io/2017/01/11/anim_compression_unreal4/#trivial_keys).
 
-## <a name="compress_independently"></a>Compress each track independently
-
+## Compress each track independently
 >  Keyframe reduction algorithm that removes keys which are linear interpolations of surrounding keys, as well as choosing the best bitwise compression for each track independently.
 
-This compression setting combines the [linear key reduction]({% post_url 2016-12-07-anim_compression_key_reduction %}) algorithm along with the [simple quantization]({% post_url 2016-11-15-anim_compression_quantization %}) bitwise compression algorithm.
+This compression setting combines the [linear key reduction](http://nfrechette.github.io/2016/12/07/anim_compression_key_reduction/) algorithm along with the [simple quantization](http://nfrechette.github.io/2016/11/15/anim_compression_quantization/) bitwise compression algorithm.
 
-It uses various custom [error metrics]({% post_url 2016-11-01-anim_compression_accuracy %}) which appears local in nature with some adaptive bias.
-Each encoding format will be tested for each track and the best result will be used based on the desired error threshold.
+It uses various custom [error metrics](http://nfrechette.github.io/2016/11/01/anim_compression_accuracy/) which appear local in nature with some adaptive bias. Each encoding format will be tested for each track and the best result will be used based on the desired error threshold.
 
-## <a name="automatic_setting"></a>Automatic
-
+## Automatic
 >  Animation compression algorithm that is just a shell for trying the range of other compression schemes and picking the smallest result within a configurable error threshold.
 
-Internally, a large mix of the previously mentioned algorithms are tested. In particular, various mixes of [sub-sampling]({% post_url 2016-11-17-anim_compression_sub_sampling %}) are tested along with [linear key reduction]({% post_url 2016-12-07-anim_compression_key_reduction %}) and [simple quantization]({% post_url 2016-11-15-anim_compression_quantization %}). The best result is selected given a specific error threshold. This is likely to be somewhat slow due to the large number of variations tested (**35** at the time of writing!).
+A large mix of the previously mentioned algorithms are tested internally. In particular, various mixes of [sub-sampling](http://nfrechette.github.io/2016/11/17/anim_compression_sub_sampling/) are tested along with [linear key reduction](http://nfrechette.github.io/2016/12/07/anim_compression_key_reduction/) and [simple quantization](http://nfrechette.github.io/2016/11/15/anim_compression_quantization/). The best result is selected given a specific error threshold. This is likely to be somewhat slow due to the large number of variations tested (**35** at the time of writing!).
 
 # Conclusion
+In memory, every compression setting has a layout that is naive with the data sorted by tracks followed by keys. This means that during decompression each track will incur a cache miss to read the compressed value.
 
-In memory, every compression setting has a layout that is naive with the data sorted by tracks followed by keys. This means that during decompression, each track will incur a cache miss to read the compressed value.
+Performance wise, decompression times are likely to be high in [Unreal 4](https://en.wikipedia.org/wiki/Unreal_Engine#Unreal_Engine_4) in large part due to the memory layout not being cache friendly and the lack of an acceleration structure such as a cursor when linear key reduction is used; and it is likely used often with the *Automatic* setting. This is an obvious area where it could improve.
 
-Performance wise, decompression times are likely to be high in [Unreal 4](https://en.wikipedia.org/wiki/Unreal_Engine#Unreal_Engine_4) in large part due to the memory layout not being cache friendly and the lack of an acceleration structure such as a cursor when linear key reduction is used (and it is likely used often with the *Automatic* setting). This is an obvious area where it could improve.
-
-Memory wise, the linear key reduction algorithm should be fairly conservative but it could be minimally improved by ditching the local space [error metric]({% post_url 2016-11-01-anim_compression_accuracy %}). Coupled with the bitwise compression, it should yield a reasonable memory footprint (*although it could be further improved by using more advanced quantization techniques as I will show at the GDC 2017*).
+Memory wise, the linear key reduction algorithm should be fairly conservative but it could be minimally improved by ditching the local space [error metric](http://nfrechette.github.io/2016/11/01/anim_compression_accuracy/). Coupled with the bitwise compression it should yield a reasonable memory footprint; *although it could be further improved by using more advanced quantization techniques as covered at the GDC 2017*.
 
 [Up next: Unity 5]({% post_url 2017-01-30-anim_compression_unity5 %})
 
 [**Back to table of contents**]({% post_url 2016-10-21-anim_compression_toc %})
-

--- a/_posts/2017-01-30-anim_compression_unity5.md
+++ b/_posts/2017-01-30-anim_compression_unity5.md
@@ -2,122 +2,118 @@
 layout: post
 title: "Animation Compression: Unity 5"
 ---
-[Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) is a very popular video game engine on mobile devices and other platforms. Being a state of the art game engine, it supports everything you might need when it comes to character animation, including animation compression.
+[![Unity 5 Official Trailer](https://img.youtube.com/vi/AJ6Mkx1KEns/0.jpg)](https://www.youtube.com/watch?v=AJ6Mkx1KEns "Unity 5 Official Trailer")
 
-The relevant documentation is very sparse and can be found [here](https://docs.unity3d.com/Manual/FBXImporter-Animations.html) and [here](https://docs.unity3d.com/Manual/class-AnimationClip.html). Note that I do not have access to the [Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) source code and as such there is some amount of uncertainty and speculation. However, I was able to get in touch with an old colleague working at [Unity](https://en.wikipedia.org/wiki/Unity_(game_engine)) to clarify what happens under the hood.
+[Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) is a very popular video game engine on mobile devices and other platforms. Being a state of the art game engine, it supports everything you might need when it comes to character animation including compression.
 
-Before we dig into what each compression setting does, we must first cover briefly the data representations that [Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) uses internally.
+The relevant [FBX Importer](https://docs.unity3d.com/Manual/FBXImporter-Animations.html) and [Animation Clip](https://docs.unity3d.com/Manual/class-AnimationClip.html) documentation is very sparse. It’s worth mentioning that [Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) is a closed source software and as such, there is some amount of uncertainty and speculation. However, I was able to get in touch with an old colleague working at [Unity](https://en.wikipedia.org/wiki/Unity_(game_engine)) to clarify what happens under the hood.
+
+Before we dig into what each compression setting does we must first briefly cover the data representations that [Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) uses internally.
 
 # Track Data Encoding
+The engine uses one of three encodings to represent an animation track regardless of the track data type (quaternion, vector, float, etc.):
+*   [Legacy Curve](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#legacy_curve)
+*   [Streaming Curve](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#streaming_curve)
+*   [Dense Curve](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#dense_curve)
 
-Internally, the engine uses one of three encodings to represent an animation track regardless of the track data type (quaternion, vector, float, etc.):
+Rotation tracks are always encoded as four curves to represent a full quaternion (one curve per component). An obvious win here could be to instead encode rotations as quaternion logarithms or by dropping the quaternion **W** component or the largest component. This would of course immediately reduce the memory footprint for rotation tracks by **25%** at the expense of a few instructions to reconstruct the original quaternion.
 
-*  [Legacy Curve](#legacy_curve)
-*  [Streaming Curve](#streaming_curve)
-*  [Dense Curve](#dense_curve)
+## Legacy Curve
+Legacy curves are a strange beast. The source data is sampled uniformly at a fixed interval such as **30 FPS** and is kept unsorted in full precision. Using discreet samples during decompression a [Hermite curve](https://en.wikipedia.org/wiki/Cubic_Hermite_spline) is constructed on the fly and interpolated. It is unclear to me how this format emerged but it has since been superseded by the other two and it is not frequently used.
 
-It is worth noting that rotation tracks are always encoded as four curves to represent a full quaternion (one curve per component). An obvious win here could be to instead encode rotations as quaternion logarithms or by dropping the quaternion **W** component (or the largest component). This would of course immediately reduce the memory footprint for rotation tracks by **25%** at the expense of a few instructions to reconstruct the original quaternion.
+It must have been quite slow to decompress and should probably be avoided.
 
-## <a name="legacy_curve"></a>Legacy Curve
+## Streaming Curve
+Streaming curves are proper curves that use [Hermite coefficients](https://en.wikipedia.org/wiki/Cubic_Hermite_spline). A track is split into intervals and each interval is encoded as a distinct spline. This allows discontinuities between intervals. For example, a camera cut or teleporting the root in a cinematic. Each interval has a small header of **8** bytes and each control point is stored in full floating point precision plus an index. This is likely overkill. Full floating point precision is typically far too much for encoding rotations and using [simple quantization](http://nfrechette.github.io/2016/11/15/anim_compression_quantization/) to store them on 16 bits per component or less could provide significant memory savings.
 
-Legacy curves are a strange beast. The source data is sampled uniformly at a fixed interval such as **30 FPS** and is kept unsorted in full precision. During decompression, using the discreet samples, an [Hermite curve](https://en.wikipedia.org/wiki/Cubic_Hermite_spline) is constructed on the fly and interpolated. It is unclear to me how this format emerged but it has since been superseded by the other two and it is unlikely to be used.
+The resulting control points are sorted by time followed by track to render them in a cache as efficient as possible which is a very good thing. At decompression, a cursor or cache is used to avoid repeatedly searching for our control points when playback is continuous and predictable. For these two reasons streaming curves are very fast to decompress in the average use case.
 
-It must have been quite slow to decompress and for this reason, it should be avoided.
+## Dense Curve
+What [Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) calls a dense curve I would call a raw format. The original source data is sampled at a fixed interval such as **30 FPS** and nothing more is done to it as far as I am aware. The data is sorted to make it cache efficient by time and track. No [linear key reduction](http://nfrechette.github.io/2016/12/07/anim_compression_key_reduction/) is performed or attempted. The sampled values are not quantized and are simply stored with full precision.
 
-## <a name="streaming_curve"></a>Streaming Curve
+Dense curves will typically have a smaller memory footprint than [streaming curves](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#streaming_curve) only for very short tracks or for tracks where the data is very noisy such as a motion capture. For this reason, they are unlikely to be used in practice.
 
-Streaming curves are proper curves: they use [Hermite coefficients](https://en.wikipedia.org/wiki/Cubic_Hermite_spline). A track is split into intervals, and each interval is encoded as a distinct spline. This allows discontinuities between intervals (e.g. a camera cut or teleporting the root in a cinematic). Each interval has a small header of **8** bytes and each control point is stored in full floating point precision plus an index. This is likely overkill, full floating point precision is typically far too much for encoding rotations and using [simple quantization]({% post_url 2016-11-15-anim_compression_quantization %}) to store them on **16** bits per component or less could give them significant memory savings.
-
-The resulting control points are sorted by time followed by track to render them as cache efficient as possible which is a very good thing. At decompression, a cursor or cache is used to avoid repeatedly searching for our control points when playback is continuous and predictable. For these two reasons, streaming curves are very fast to decompress in the average use case.
-
-## <a name="dense_curve"></a>Dense Curve
-
-What [Unity](https://en.wikipedia.org/wiki/Unity_(game_engine)) calls a dense curve is what I would call a raw format. The original source data is sampled at a fixed interval such as **30 FPS** and nothing more is done to it as far as I am aware. The data is sorted to make it cache efficient by time and track. No [linear key reduction]({% post_url 2016-12-07-anim_compression_key_reduction %}) is performed or attempted. The sampled values are not quantized and are simply stored with full precision.
-
-Dense curves will typically have a smaller memory footprint than [streaming curves](#streaming_curve) only for very short tracks or for tracks where the data is very noisy (such as from motion capture). For this reason, they are unlikely to be used in practice.
-
-Overall, their implementation is simple but perhaps a bit naive. Using [simple quantization]({% post_url 2016-11-15-anim_compression_quantization %}) would give significant memory gains here without degrading decompression performance (it might even speed it up!). On the upside, decompression speed is very likely to be faster than with streaming curves.
+Overall their implementation is simple but perhaps a bit naive. Using [simple quantization](http://nfrechette.github.io/2016/11/15/anim_compression_quantization/) would give significant memory gains here without degrading decompression performance and might even speed it up! On the upside decompression speed is very likely to be faster than with streaming curves.
 
 # Compression Settings
-
 At the time of writing, [Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) supports three compression settings:
+*   [No Compression](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#no_compression)
+*   [Keyframe Reduction](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#keyframe_reduction)
+*   [Optimal](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#optimal)
 
-*  [No Compression](#no_compression)
-*  [Keyframe Reduction](#keyframe_reduction)
-*  [Optimal](#optimal)
-
-## <a name="no_compression"></a>No Compression
-
-The most detailed quote from the documentation as to what this compression setting does is as follow:
+## No Compression
+The most detailed quote from the documentation about what this setting does is:
 
 >  Disables animation compression. This means that Unity doesn’t reduce keyframe count on import, which leads to the highest precision animations, but slower performance and bigger file and runtime memory size. It is generally not advisable to use this option - if you need higher precision animation, you should enable keyframe reduction and lower allowed Animation Compression Error values instead.
 
-From what I could gather, the original imported clip is sampled uniformly (e.g. **30 FPS**) and each track is converted into a [streaming curve](#streaming_curve). This ensures everything remains smooth and accurate but the overhead can be very significant since all samples are retained. To make things worst, nothing is done for constant tracks with this setting.
+From what I could gather the originally imported clip is sampled uniformly (e.g. **30 FPS**) and each track is converted into a [streaming curve](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#streaming_curve). This ensures everything remains smooth and accurate but the overhead can be very significant since all samples are retained. To make things worse nothing is done for constant tracks with this setting.
 
-## <a name="keyframe_reduction"></a>Keyframe Reduction
-
+## Keyframe Reduction
 The most detailed quote from the documentation is:
 
->  Removes redundant keyframes
+>  Removes redundant keyframes.
 
-When this setting is used, constant tracks will be collapsed to a single value and redundant control points in animated tracks will be removed within the specified error threshold. This setting will use [streaming curves](#streaming_curve) to represent the track data.
+When this setting is used constant tracks will be collapsed to a single value and redundant control points in animated tracks which will be removed within the specified error threshold. This setting uses [streaming curves](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#streaming_curve) to represent track data.
 
-Only three thresholds are exposed for this compression setting, one for each track type: rotation, translation, and scale. This is very likely to lead to problems as we have discussed when we covered how to [measure accuracy]({% post_url 2016-11-01-anim_compression_accuracy %}). And indeed, a quick search yields [this gem](https://forum.unity3d.com/threads/animation-cost-key-reducer.42841/). Even though it dates from [Unity 3](https://en.wikipedia.org/wiki/Unity_(game_engine)) (2010), I doubt the animation compression changed much and the problems it raises are all very telling and common with local space error metric functions. Here are some relevant excerpts:
+Only three thresholds are exposed for this compression setting. One for each track type: rotation, translation, and scale. This is very likely to lead to the problems discussed in my post on [measuring accuracy](http://nfrechette.github.io/2016/11/01/anim_compression_accuracy/). And indeed, a quick search yields [this gem](https://forum.unity3d.com/threads/animation-cost-key-reducer.42841/). Even though it dates from [Unity 3(2010)](https://en.wikipedia.org/wiki/Unity_(game_engine)), I doubt the animation compression has changed much. Unfortunately, the problems it raises are both very telling and common with local space error metric functions. Here are some relevant excerpts:
 
->  Now, you may be asking yourself, why would this guy turn off the key reducer in the first place?  The answer is simple. The key reducer sucks.  Here's why.  
-&nbsp;  
-Every animation I have completed for this project uses planted keys to anchor the feet (and sometimes hands) to the floor. This allows me to grab any part of the body and animate it, knowing that the feet will not move.   When I export the FBX, the keys stay intact. I can bring the animation back into Max or into Maya using the keyframe reducer for either software, and the feet remain anchored. When I bring the same FBX into Unity the feet slide around. Often quite noticably.  The only way to stop the feet from sliding is to turn off the key reducer.
+>  Now, you may be asking yourself, why would this guy turn off the key reducer in the first place? The answer is simple. The key reducer sucks. Here’s why.
+>
+>  Every animation I have completed for this project uses planted keys to anchor the feet (and sometimes hands) to the floor. This allows me to grab any part of the body and animate it, knowing that the feet will not move. When I export the FBX, the keys stay intact. I can bring the animation back into Max or into Maya using the keyframe reducer for either software, and the feet remain anchored. When I bring the same FBX into Unity the feet slide around. Often quite noticably. The only way to stop the feet from sliding is to turn off the key reducer.
 
-This is a very common problem with local space error functions: tweaking them is hard. The end result is that very often a weaker or no compression is used when issues are found (on a clip by clip basis). I have seen this exact behaviour from animators working on [Unreal 3](https://en.wikipedia.org/wiki/Unreal_Engine#Unreal_Engine_3) back in the day and very recently in a proprietary AAA game engine. Even though from the user’s perspective the issue is the animation compression algorithm, in reality the issue is almost entirely due to the error function.
+This is a very common problem with local space error functions. Tweaking them is hard! The end result is that very often a weaker compression or no compression at all is used when issues are found on a clip by clip basis. I have seen this exact behavior from animators working on [Unreal 3](https://en.wikipedia.org/wiki/Unreal_Engine#Unreal_Engine_3) back in the day and very recently in a proprietary AAA game engine. Even though from the user’s perspective the issue is the animation compression algorithm, in reality, the issue is almost entirely due to the error function.
 
->  What I would really like to see is some options within Unity's animation importer. A couple ideas:  
-&nbsp;  
-1) Max's FBX keyframe reduction has several precision threshold settings that dictate how accurate the keyframe reduction should be. In Unity, it's all or nothing. I would love the ability to adjust the threshold in which a keyframe gets added. I could turn up the sensitivity on some animations to reduce sliding and possibly turn it down on areas that need fewer keys than are given by the current value.  
-&nbsp;  
-2) I'm not sure if this is possible, but it would be great to set keyframe reductions on some bones and not others. That way I can keep the arm chain in the proper location without having to bloat the keyframes of every bone in the whole skeleton.
+>  What I would really like to see is some options within Unity’s animation importer. A couple ideas:
+>
+>  1) Max’s FBX keyframe reduction has several precision threshold settings that dictate how accurate the keyframe reduction should be. In Unity, it’s all or nothing. I would love the ability to adjust the threshold in which a keyframe gets added. I could turn up the sensitivity on some animations to reduce sliding and possibly turn it down on areas that need fewer keys than are given by the current value.
+>
+>  2) I’m not sure if this is possible, but it would be great to set keyframe reductions on some bones and not others. That way I can keep the arm chain in the proper location without having to bloat the keyframes of every bone in the whole skeleton.
 
-Exposing a single error threshold per track type is very common and a source of frustration for animators. They often know which bones need higher accuracy but are unable to properly tweak per bone thresholds. Sadly, when this feature is present, the settings often end up being copy & pasted with overly conservative values which yields a higher than needed memory footprint. Nobody has time to tweak a large number of thresholds repeatedly.
+Exposing a single error threshold per track type is very common and provides a source of frustration for animators. They often know which bones need higher accuracy but are unable to properly tweak per bone thresholds. Sadly, when this feature is present the settings often end up being copy & pasted with overly conservative values which yield a higher than needed memory footprint. Nobody has time to tweak a large number of thresholds repeatedly.
 
 >  Unity 3 actually corrects the problem by giving us direct control over the keyframe reduction vs allowable error. If you find your animation is sliding to much, dial down the Position Error and/or Rotation Error settings in the animation import settings.
+>
+>  Unfortunately, I didn’t find any satisfying setup :/
+>
+>  I got some characters that move super fast in their anim, and I need the player to see the move correctly for gameplay / balance reasons.
+>
+>  So it can works for some anims, but not for others (making them feel like they are teleporting).
+>
+>  And under a certain reduction threshold, the memory size benefit is too small to resolve loading times problem :/
+>
+>  In fact, the only reduction setting I found that didn’t caused teleportations was :
+>
+>  Position : 0.1
+>  Rotation : 0.1
+>  Scale : 0 (as there is never any animated scale)
+>
+>  But this is still causing huge file sizes :(
 
->  Unfortunately, I didn't find any satisfying setup :/  
-I got some characters that move super fast in their anim, and I need the player to see the move correctly for gameplay / balance reasons.  
-So it can works for some anims, but not for others (making them feel like they are teleporting).  
-&nbsp;  
-And under a certain reduction threshold, the memory size benefit is too small to resolve loading times problem :/  
-&nbsp;  
-In fact, the only reduction setting I found that didn't caused teleportations was :  
-Position : 0.1  
-Rotation : 0.1  
-Scale : 0 (as there is never any animated scale)  
-&nbsp;  
-But this is still causing huge file sizes :(
+A single error threshold per track type also means that the error threshold has to be as low as your most sensitive bone requires. This will, in turn, retain higher accuracy that might otherwise be needed yielding again a higher memory footprint that is often unacceptable.
 
-A single error threshold per track type also means that the error threshold has to be as low as your most sensitive bone requires. This will in turn retain higher accuracy that might otherwise be needed, yielding again a higher memory footprint that is often unacceptable.
-
-## <a name="optimal"></a>Optimal
-
+## Optimal
 The most detailed quote from the documentation is:
 
 >  Let unity decide how to compress. Either by keyframe reduction or by using dense format. Unity will pick the most optimal of the two.
 
-This is very vague, and judging from the results of a [quick](http://answers.unity3d.com/questions/822418/what-are-the-differences-between-animation-compres.html) [search](http://answers.unity3d.com/questions/1180871/what-did-unitys-animation-compression-options-opti.html), a lot of people are curious.
+This is very vague and judging from [the results](http://answers.unity3d.com/questions/822418/what-are-the-differences-between-animation-compres.html) of a [quick search](http://answers.unity3d.com/questions/1180871/what-did-unitys-animation-compression-options-opti.html), a lot of people are curious.
 
 Thankfully, I was able to get some answers!
 
-If a track is very short or very noisy (which could happen with motion capture clips or baked simulations), the key reduction algorithm might not give appreciable gains and it is possible that a [dense curve](#dense_curve) might end up having a smaller memory footprint than a [streaming curve](#streaming_curve). When this happens for a particular track, it will use the curve with the smallest memory footprint. As such, within a single clip, we can have a mix of [dense](#dense_curve) and [streaming](#streaming_curve) curves.
+If a track is very short or very noisy (which could happen with motion capture clips or baked simulations), the key reduction algorithm might not give appreciable gains and it is possible that a [dense curve](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#dense_curve) might end up having a smaller memory footprint than a [streaming curve](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#streaming_curve). When this happens for a particular track it will use the curve with the smallest memory footprint. As such, within a single clip, we can have a mix of [dense](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#dense_curve) and [streaming](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#streaming_curve) curves.
 
 # Conclusion
-
-The [Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) documentation is sparse and at times unclear. It leads to rampant speculation as to what might be going on under the hood and a lot of confusion results.
+The [Unity 5](https://en.wikipedia.org/wiki/Unity_(game_engine)) documentation is sparse and at times unclear. It leads to rampant speculation as to what might be going on under the hood and a lot of confusing results.
 
 Its error function is poor, exposing a single value per track type. This leads to classic issues such as turning compression off to retain accuracy and using an overly conservative threshold to retain accuracy at the expense of the memory footprint. It perpetuates the stigma that animation compression can be painful to work with and can easily butcher an animator’s work without manual tweaking. Fixing the error function could be a reasonably simple task.
 
-The optimal compression setting seems a very reasonable default value but it is not clear why the other two are exposed at all. Users are very likely to use one of the other settings instead of tweaking the error function thresholds which is probably a bad idea.
+The optimal compression setting seems to be a very reasonable default value but it is not clear why the other two are exposed at all. Users are very likely to use one of the other settings instead of tweaking the error function thresholds which is probably a bad idea.
 
-All curve types encode the data in full precision with **32** bit floating point numbers. This is very likely overkill in a very large number of scenarios and implementing some form of [simple quantization]({% post_url 2016-11-15-anim_compression_quantization %}) could give them very large memory gains with very little work or effort. Due to the reduced memory footprint, decompression timings might even improve. Furthermore, rotation tracks could be encoded in a better format than a full quaternion, further reducing the memory footprint for minimal work.
+All curve types encode the data in full precision with **32-bit** floating point numbers. This is likely overkill in a very large number of scenarios and implementing some form of [simple quantization](http://nfrechette.github.io/2016/11/15/anim_compression_quantization/) could provide huge memory gains with little work and little effort. Due to the reduced memory footprint, decompression timings might even improve.
 
-From what I could find, nobody seemed to complain about animation decompression performance at runtime. This is mostly likely a direct result of the cache friendly data format and the usage of a cursor for [streaming curves](#streaming_curve).
+Furthermore, rotation tracks could be encoded in a better format than a full quaternion further reducing the memory footprint for minimal work.
+
+From what I could find nobody seemed to complain about animation decompression performance at runtime. This is mostly likely a direct result of the cache friendly data format and the usage of a cursor for [streaming curves](http://nfrechette.github.io/2017/01/30/anim_compression_unity5/#streaming_curve).
+
 
 [**Back to table of contents**]({% post_url 2016-10-21-anim_compression_toc %})
-


### PR DESCRIPTION
Minor to heavy re-wording in places and all the technical jargon left as is. Ran through a grammar, punctuation, and readability check and made edits as appropriate. Spent about 6 hours.

I changed the TOC to be written from the point of your talk being in the past instead of upcoming. Where referenced elsewhere I followed that rule. The diffs look pretty dramatic and I'd say about 80% of paragraphs have edits - usually 1 or 2 really minor edits and 1 sentence fully restructured per paragraph.

I included a video thumbnail at the top of the Unity and Unreal posts.

Ran minor markdown linting throughout. 

Read lines 16 through 25 on the measuring accuracy documents. I fixed a grammatical error but wasn't sure if I changed the message being communicated - it was pretty technical stuff at that particular spot.